### PR TITLE
Update filestoragecontainer-post-permissions.md

### DIFF
--- a/api-reference/beta/api/filestoragecontainer-post-permissions.md
+++ b/api-reference/beta/api/filestoragecontainer-post-permissions.md
@@ -42,11 +42,10 @@ POST /storage/fileStorage/containers/{fileStorageContainerId}/permissions
 
 ## Request body
 In the request body, supply a JSON representation of the [permission](../resources/permission.md) object with the following properties.
-|Name|Type|Description|
-|:---|:---|:---|
-|**roles**|String|The type of permissions. Either `reader`, `writer`, `manager`, or `owner`.|
-|**grantedToV2**|[sharePointIdentitySet](../resources/sharepointidentityset.md)|For user type permissions, the details of the user for this permission.|
-
+|     Name    |                              Type                              | Description                                                                |
+|:-----------:|:--------------------------------------------------------------:|----------------------------------------------------------------------------|
+| roles       | String                                                         | The type of permissions. Either `reader`, `writer`, `manager`, or `owner`. |
+| grantedToV2 | [sharePointIdentitySet](../resources/sharepointidentityset.md) | For user type permissions, the details of the user for this permission.    |
 ## Response
 
 If successful, this method returns a `201 Created` response code and a [permission](../resources/permission.md) object in the response body.


### PR DESCRIPTION
Fix the table formatting. Although the table renders on GitHub, on Learn it doesn't render and just shows raw markdown making the table unreadable and unusable.